### PR TITLE
Mathjax CDN修正

### DIFF
--- a/layout/_scripts/mathjax.ejs
+++ b/layout/_scripts/mathjax.ejs
@@ -1,6 +1,6 @@
 <% if ( theme.mathjax ) {  %>
 
-    <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <script type="text/javascript"> 
         $(document).ready(function(){
             MathJax.Hub.Config({ 


### PR DESCRIPTION
cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ 
原cdn已停止工作，改为mathjax官网建议的新cdn (见 https://www.mathjax.org/cdn-shutting-down/ )，使用和原来一样的”最新版本“（尽管含有2.7.5，但官网说这种方法一直是最新版本）